### PR TITLE
Implement stamina mechanics

### DIFF
--- a/HackmonFrontend/ActionSelectUI.cs
+++ b/HackmonFrontend/ActionSelectUI.cs
@@ -31,7 +31,7 @@ public partial class ActionSelectUI : Control
 		{
 			CurrentSelection = selection;
 			var currentMove = SelectableActions[selection];
-			Infobox.Text = $"{currentMove.Description}\nType: {currentMove.AttackType}\nDamage: {currentMove.Damage}";
+			Infobox.Text = $"{currentMove.Description}\nType: {currentMove.AttackType}\nDamage: {currentMove.Damage}      Cost: {currentMove.StaminaCost}";
 		}
 	}
 

--- a/HackmonFrontend/Battle.cs
+++ b/HackmonFrontend/Battle.cs
@@ -33,6 +33,7 @@ public partial class Battle : Node2D
 
 		HackmonBattleManager.HandleInput(new() { action });
 		processEvents = true;
+		trainerUI.DoStaminaAnim(move.StaminaCost);
 	}
 
 	private void OnMessagesDone()

--- a/HackmonFrontend/Battle.cs
+++ b/HackmonFrontend/Battle.cs
@@ -29,6 +29,12 @@ public partial class Battle : Node2D
 
 	private void OnPlayerInput(HackmonMove move)
 	{
+		
+		if (move.StaminaCost > ActivePlayerMon.Stamina)
+		{
+			GD.Print("Selection failed. Not enough stamina.");
+			return;
+		}
 		var action = new AttackAction(ActivePlayerMon, ActiveEnemyMon, new AttackResolver(move));
 
 		HackmonBattleManager.HandleInput(new() { action });

--- a/HackmonFrontend/Battle.cs
+++ b/HackmonFrontend/Battle.cs
@@ -26,8 +26,10 @@ public partial class Battle : Node2D
 	private bool processEvents = false;
 	private bool itsSoOver = false;
 	private List<string> messageList = new();
-	private int _preRegenStamina = 0;
-	private int _preRegenHealth = 0;
+	private int _playerPreRegenStamina = 0;
+	private int _playerPreRegenHealth = 0;
+	private int _enemyPreRegenStamina = 0;
+	private int _enemyPreRegenHealth = 0;
 
 	private void OnPlayerInput(HackmonMove move)
 	{
@@ -49,8 +51,10 @@ public partial class Battle : Node2D
 	private void OnMessagesDone()
 	{
 		eventText.Disable();
-		trainerUI.DoStamRegenAnim(ActivePlayerMon.Stamina - _preRegenStamina);
-		trainerUI.DoHpRegenAnim(ActivePlayerMon.Health - _preRegenHealth);
+		trainerUI.DoStamRegenAnim(ActivePlayerMon.Stamina - _playerPreRegenStamina);
+		trainerUI.DoHpRegenAnim(ActivePlayerMon.Health - _playerPreRegenHealth);
+		enemyUI.DoStamRegenAnim(ActiveEnemyMon.Stamina - _enemyPreRegenStamina);
+		enemyUI.DoHpRegenAnim(ActiveEnemyMon.Health - _enemyPreRegenHealth);
 		if (itsSoOver) return;
 		actionSelect.SetEnabled(true);
 	}
@@ -129,11 +133,17 @@ public partial class Battle : Node2D
 						processEvents = false;
 						if (ActivePlayerMon.Stamina < ActivePlayerMon.MaxStamina)
 						{
-							_preRegenStamina = ActivePlayerMon.Stamina;
-							_preRegenHealth = ActivePlayerMon.Health;
-							ActivePlayerMon.Stamina += ActivePlayerMon.MaxStamina / 4;
+							_playerPreRegenStamina = ActivePlayerMon.Stamina;
+							_playerPreRegenHealth = ActivePlayerMon.Health;
+							ActivePlayerMon.Stamina += ActivePlayerMon.MaxStamina / 8;
 							ActivePlayerMon.Stamina = Math.Min(ActivePlayerMon.Stamina, ActivePlayerMon.MaxStamina);
-							GD.Print($"Restored Player Stamina by {ActivePlayerMon.MaxStamina / 4}.");
+						}
+						if (ActiveEnemyMon.Stamina < ActiveEnemyMon.MaxStamina)
+						{
+							_enemyPreRegenStamina = ActiveEnemyMon.Stamina;
+							_enemyPreRegenHealth = ActiveEnemyMon.Health;
+							ActiveEnemyMon.Stamina += ActiveEnemyMon.MaxStamina / 8;
+							ActiveEnemyMon.Stamina = Math.Min(ActiveEnemyMon.Stamina, ActiveEnemyMon.MaxStamina);
 						}
 						break;
 					case HackmonHitEvent hitEvent:

--- a/HackmonFrontend/Battle.cs
+++ b/HackmonFrontend/Battle.cs
@@ -33,7 +33,7 @@ public partial class Battle : Node2D
 
 		HackmonBattleManager.HandleInput(new() { action });
 		processEvents = true;
-		trainerUI.DoStaminaAnim(move.StaminaCost);
+		//trainerUI.DoStaminaAnim(move.StaminaCost);
 	}
 
 	private void OnMessagesDone()
@@ -123,10 +123,12 @@ public partial class Battle : Node2D
 						messageList.Add(eventStr);
 						if (ActivePlayerMon == hitEvent.Attacker)
 						{
+							trainerUI.DoStaminaAnim(hitEvent.Attack.StaminaCost);
 							enemyUI.DoDamageAnim(hitEvent.Damage);    
 						}
 						else
 						{
+							enemyUI.DoStaminaAnim(hitEvent.Attack.StaminaCost);
 							trainerUI.DoDamageAnim(hitEvent.Damage);
 						}
 						break;

--- a/HackmonFrontend/Battle.cs
+++ b/HackmonFrontend/Battle.cs
@@ -26,6 +26,8 @@ public partial class Battle : Node2D
 	private bool processEvents = false;
 	private bool itsSoOver = false;
 	private List<string> messageList = new();
+	private int _preRegenStamina = 0;
+	private int _preRegenHealth = 0;
 
 	private void OnPlayerInput(HackmonMove move)
 	{
@@ -47,6 +49,8 @@ public partial class Battle : Node2D
 	private void OnMessagesDone()
 	{
 		eventText.Disable();
+		trainerUI.DoStamRegenAnim(ActivePlayerMon.Stamina - _preRegenStamina);
+		trainerUI.DoHpRegenAnim(ActivePlayerMon.Health - _preRegenHealth);
 		if (itsSoOver) return;
 		actionSelect.SetEnabled(true);
 	}
@@ -123,6 +127,14 @@ public partial class Battle : Node2D
 						eventText.ShowMessages(new List<string>(messageList), OnMessagesDone);
 						messageList.Clear();
 						processEvents = false;
+						if (ActivePlayerMon.Stamina < ActivePlayerMon.MaxStamina)
+						{
+							_preRegenStamina = ActivePlayerMon.Stamina;
+							_preRegenHealth = ActivePlayerMon.Health;
+							ActivePlayerMon.Stamina += ActivePlayerMon.MaxStamina / 4;
+							ActivePlayerMon.Stamina = Math.Min(ActivePlayerMon.Stamina, ActivePlayerMon.MaxStamina);
+							GD.Print($"Restored Player Stamina by {ActivePlayerMon.MaxStamina / 4}.");
+						}
 						break;
 					case HackmonHitEvent hitEvent:
 						GD.Print("adding message.");

--- a/HackmonFrontend/Battle.cs
+++ b/HackmonFrontend/Battle.cs
@@ -29,10 +29,12 @@ public partial class Battle : Node2D
 
 	private void OnPlayerInput(HackmonMove move)
 	{
-		
 		if (move.StaminaCost > ActivePlayerMon.Stamina)
 		{
-			GD.Print("Selection failed. Not enough stamina.");
+			actionSelect.SetEnabled(false);
+			eventText.Enable();
+			eventText.ShowMessages(new List<string> {"Not enough stamina!"}, OnMessagesDone);
+			GD.Print("Nostamina.");
 			return;
 		}
 		var action = new AttackAction(ActivePlayerMon, ActiveEnemyMon, new AttackResolver(move));

--- a/HackmonFrontend/BattlerUI.cs
+++ b/HackmonFrontend/BattlerUI.cs
@@ -49,10 +49,22 @@ public partial class BattlerUI : Panel
 		_healthCurrentChange = damage;
 		_tweenTimePassed = 0;
 	}
+	public void DoHpRegenAnim(int health)
+	{
+		_healthValueBeforeChange = _healthBar.Value;
+		_healthCurrentChange = -health;
+		_tweenTimePassed = 0;
+	}
 	public void DoStaminaAnim(int staminaCost)
 	{
 		_staminaValueBeforeChange = _staminaBar.Value;
 		_staminaCurrentChange = staminaCost;
+		_tweenTimePassed = 0;
+	}
+	public void DoStamRegenAnim(int stamina)
+	{
+		_staminaValueBeforeChange = _staminaBar.Value;
+		_staminaCurrentChange = -stamina;
 		_tweenTimePassed = 0;
 	}
 

--- a/HackmonFrontend/BattlerUI.cs
+++ b/HackmonFrontend/BattlerUI.cs
@@ -7,6 +7,7 @@ public partial class BattlerUI : Panel
 	private HackmonInstance _currentHackmon;
 	private RichTextLabel _nameLabel;
 	private TextureProgressBar _healthBar;
+	private TextureProgressBar _staminaBar;
 	private int _currentChange = 0;
 	private double _valueBeforeChange;
 	private readonly double _tweenTime = 0.5;
@@ -18,6 +19,8 @@ public partial class BattlerUI : Panel
 		_nameLabel.Text = mon.Name;
 		_healthBar.MaxValue = mon.MaxHp;
 		_healthBar.Value = mon.Health;
+		_staminaBar.MaxValue = mon.MaxStamina;
+		_staminaBar.Value = mon.Stamina;
 		//_healthBar.ShowPercentage = true;
 
 		var _primaryTypeImageNode = GetNode<Sprite2D>("Status/PrimarySocket/PrimaryType");

--- a/HackmonFrontend/BattlerUI.cs
+++ b/HackmonFrontend/BattlerUI.cs
@@ -52,6 +52,7 @@ public partial class BattlerUI : Panel
 	{
 		_nameLabel = GetNode<RichTextLabel>("Status/Name");
 		_healthBar = GetNode<TextureProgressBar>("Status/HealthBar");
+		_staminaBar = GetNode<TextureProgressBar>("Status/StaminaBar");
 	}
 
 	public override void _Process(double delta)

--- a/HackmonFrontend/BattlerUI.cs
+++ b/HackmonFrontend/BattlerUI.cs
@@ -8,8 +8,10 @@ public partial class BattlerUI : Panel
 	private RichTextLabel _nameLabel;
 	private TextureProgressBar _healthBar;
 	private TextureProgressBar _staminaBar;
-	private int _currentChange = 0;
-	private double _valueBeforeChange;
+	private int _healthCurrentChange = 0;
+	private int _staminaCurrentChange = 0;
+	private double _healthValueBeforeChange;
+	private double _staminaValueBeforeChange;
 	private readonly double _tweenTime = 0.5;
 	private double _tweenTimePassed = 0.5;
 
@@ -43,8 +45,14 @@ public partial class BattlerUI : Panel
 
 	public void DoDamageAnim(int damage)
 	{
-		_valueBeforeChange = _healthBar.Value;
-		_currentChange = damage;
+		_healthValueBeforeChange = _healthBar.Value;
+		_healthCurrentChange = damage;
+		_tweenTimePassed = 0;
+	}
+	public void DoStaminaAnim(int staminaCost)
+	{
+		_staminaValueBeforeChange = _staminaBar.Value;
+		_staminaCurrentChange = staminaCost;
 		_tweenTimePassed = 0;
 	}
 
@@ -62,13 +70,16 @@ public partial class BattlerUI : Panel
 			_tweenTimePassed += delta;
 			if (_tweenTimePassed >= _tweenTime)
 			{
-				_healthBar.Value = _valueBeforeChange - _currentChange;
+				_healthBar.Value = _healthValueBeforeChange - _healthCurrentChange;
+				_staminaBar.Value = _staminaValueBeforeChange - _staminaCurrentChange;
 				_tweenTimePassed = _tweenTime;
-				_currentChange = 0;
+				_healthCurrentChange = 0;
+				_staminaCurrentChange = 0;
 			}
 			else
 			{
-				_healthBar.Value = _valueBeforeChange - (_currentChange * (_tweenTimePassed / _tweenTime));
+				_healthBar.Value = _healthValueBeforeChange - (_healthCurrentChange * (_tweenTimePassed / _tweenTime));
+				_staminaBar.Value = _staminaValueBeforeChange - (_staminaCurrentChange * (_tweenTimePassed / _tweenTime));
 			}
 		}
 	}

--- a/HackmonFrontend/Hackmon.csproj
+++ b/HackmonFrontend/Hackmon.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.4.0">
+<Project Sdk="Godot.NET.Sdk/4.4.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>HackmonFrontend</RootNamespace>

--- a/HackmonInternals/Battle/AttackResolver.cs
+++ b/HackmonInternals/Battle/AttackResolver.cs
@@ -32,6 +32,7 @@ public class AttackResolver : IAttack
         {
             throw new Exception($"Not enough stamina for move: {AttackData.Name}");
         }
+        
         if (AttackData.Damage != 0)
         {
             var atk = 0;

--- a/HackmonInternals/Battle/AttackResolver.cs
+++ b/HackmonInternals/Battle/AttackResolver.cs
@@ -24,7 +24,14 @@ public class AttackResolver : IAttack
 
         HackmonInstance moveUser = (HackmonInstance)attacker;
         HackmonInstance moveTarget = (HackmonInstance)target;
-
+        if (AttackData.StaminaCost <= moveUser.Stamina)
+        {
+            moveUser.Stamina -= AttackData.StaminaCost;
+        }
+        else
+        {
+            throw new Exception($"Not enough stamina for move: {AttackData.Name}");
+        }
         if (AttackData.Damage != 0)
         {
             var atk = 0;

--- a/HackmonInternals/Battle/HackmonBattleManager.cs
+++ b/HackmonInternals/Battle/HackmonBattleManager.cs
@@ -76,7 +76,7 @@ public static class HackmonBattleManager
         Console.WriteLine($"eventqueue now contains {EventQueue.Count} items");
         
         Console.WriteLine(
-            $"{attacker.Name} uses {atk.AttackData.Name} on {target.Name}\nDamage: {e.Damage}. {target.Name} HP Remaining: {target.Health}");
+            $"{attacker.Name} uses {atk.AttackData.Name} for {atk.AttackData.StaminaCost} stamina on {target.Name}\nDamage: {e.Damage}. {target.Name} HP Remaining: {target.Health}");
     }
 
     private static void BattleEndCheck(DeathEvent data)

--- a/HackmonInternals/Data/Hackmon/Capratato.json
+++ b/HackmonInternals/Data/Hackmon/Capratato.json
@@ -28,5 +28,9 @@
     "BaseValue": 5,
     "GrowthPerLevel": 0.45
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+  },
   "LearnableMoves": [1,14,24,40]
 }

--- a/HackmonInternals/Data/Hackmon/Caravinia.json
+++ b/HackmonInternals/Data/Hackmon/Caravinia.json
@@ -29,5 +29,9 @@
     "BaseValue": 2,
     "GrowthPerLevel": 1.23
   },
+    "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,4,7,17,26,42,51,65,73]
 }

--- a/HackmonInternals/Data/Hackmon/Dracosoon.json
+++ b/HackmonInternals/Data/Hackmon/Dracosoon.json
@@ -29,5 +29,9 @@
     "BaseValue": 10,
     "GrowthPerLevel": 1.30
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,3,6,16,25,35]
 }

--- a/HackmonInternals/Data/Hackmon/Felibriar.json
+++ b/HackmonInternals/Data/Hackmon/Felibriar.json
@@ -28,5 +28,9 @@
     "BaseValue": 2,
     "GrowthPerLevel": 0.98
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,4,7,17,26,42,51,65,73]
 }

--- a/HackmonInternals/Data/Hackmon/Felivine.json
+++ b/HackmonInternals/Data/Hackmon/Felivine.json
@@ -28,5 +28,9 @@
     "BaseValue": 2,
     "GrowthPerLevel": 0.48
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,4,26,42,65]
 }

--- a/HackmonInternals/Data/Hackmon/Jarcairn.json
+++ b/HackmonInternals/Data/Hackmon/Jarcairn.json
@@ -29,5 +29,9 @@
     "BaseValue": 1,
     "GrowthPerLevel": 0.54
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,4,5,8,14,27,30,38,40]
 }

--- a/HackmonInternals/Data/Hackmon/Jarkin.json
+++ b/HackmonInternals/Data/Hackmon/Jarkin.json
@@ -28,5 +28,9 @@
     "BaseValue": 1,
     "GrowthPerLevel": 0.49
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,5,8,14,27,38]
 }

--- a/HackmonInternals/Data/Hackmon/Jarmor.json
+++ b/HackmonInternals/Data/Hackmon/Jarmor.json
@@ -28,5 +28,9 @@
     "BaseValue": 1,
     "GrowthPerLevel": 0.49
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,4,5,8,14,27,30,38,40]
 }

--- a/HackmonInternals/Data/Hackmon/Olmerain.json
+++ b/HackmonInternals/Data/Hackmon/Olmerain.json
@@ -28,5 +28,9 @@
     "BaseValue": 10,
     "GrowthPerLevel": 1.15
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,3,6,16,25,35]
 }

--- a/HackmonInternals/Data/Hackmon/Olmin.json
+++ b/HackmonInternals/Data/Hackmon/Olmin.json
@@ -28,5 +28,9 @@
     "BaseValue": 10,
     "GrowthPerLevel": 0.40
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,3,16,25]
 }

--- a/HackmonInternals/Data/Hackmon/Pumite.json
+++ b/HackmonInternals/Data/Hackmon/Pumite.json
@@ -28,5 +28,9 @@
     "BaseValue": 5,
     "GrowthPerLevel": 0.45
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,2,10,11,12,15]
 }

--- a/HackmonInternals/Data/Hackmon/Rhizoram.json
+++ b/HackmonInternals/Data/Hackmon/Rhizoram.json
@@ -28,5 +28,9 @@
     "BaseValue": 5,
     "GrowthPerLevel": 0.75
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,14,24,30,38,40]
 }

--- a/HackmonInternals/Data/Hackmon/Scarablast.json
+++ b/HackmonInternals/Data/Hackmon/Scarablast.json
@@ -29,5 +29,9 @@
     "BaseValue": 5,
     "GrowthPerLevel": 1.20
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,2,10,11,12,15]
 }

--- a/HackmonInternals/Data/Hackmon/TestHackmon.json
+++ b/HackmonInternals/Data/Hackmon/TestHackmon.json
@@ -28,5 +28,9 @@
     "BaseValue": 1,
     "GrowthPerLevel": 0.49
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [0,1]
 }

--- a/HackmonInternals/Data/Hackmon/Tuberam.json
+++ b/HackmonInternals/Data/Hackmon/Tuberam.json
@@ -28,5 +28,9 @@
     "BaseValue": 5,
     "GrowthPerLevel": 0.55
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,14,24,30,38,40]
 }

--- a/HackmonInternals/Data/Hackmon/Verma.json
+++ b/HackmonInternals/Data/Hackmon/Verma.json
@@ -28,5 +28,9 @@
     "BaseValue": 5,
     "GrowthPerLevel": 0.45
   },
+  "MaxStamina": {
+    "BaseValue": 1,
+    "GrowthPerLevel": 0
+},
   "LearnableMoves": [1,2,11,15,70]
 }

--- a/HackmonInternals/Models/HackmonData.cs
+++ b/HackmonInternals/Models/HackmonData.cs
@@ -14,5 +14,6 @@ public class HackmonData
     public Stat SpAttack { get; set; }
     public Stat Defense { get; set; }
     public Stat SpDefense { get; set; }
+    public Stat MaxStamina { get; set;}
     public List<int> LearnableMoves { get; set; } 
 }

--- a/HackmonInternals/Models/HackmonInstance.cs
+++ b/HackmonInternals/Models/HackmonInstance.cs
@@ -44,7 +44,7 @@ public class HackmonInstance : IUnit
 
    public int MaxHp => StaticData.MaxHp.BaseValue + (int)MathF.Round(StaticData.MaxHp.GrowthPerLevel * Level) + 99;
 
-   public int MaxStamina { get; set; } = 100;
+   public int MaxStamina => StaticData.MaxStamina.BaseValue + (int)MathF.Round(StaticData.MaxStamina.GrowthPerLevel * Level) + 99;
    
    public int Stamina { get; set; }
 


### PR DESCRIPTION
This adds stamina cost functionality to the battler scene.

- [x] Make moves consume stamina when selected and used.
- [x] Connect stamina stat to the stamina bar UI and update whenever changed for player.
- [x] Connect stamina stat to the stamina bar UI and update whenever changed for enemy.
- [x] Implement stamina regeneration at end of turn.
- [x] Prevent selection of moves when there is not enough stamina.
- [x] Display stamina cost of highlighted moves during move selection.