### PR TITLE
Created basic astral moves

### DIFF
--- a/HackmonInternals/Data/Moves/Astral/Comet.json
+++ b/HackmonInternals/Data/Moves/Astral/Comet.json
@@ -1,0 +1,12 @@
+{
+	"Id": 77,
+	"MoveType": "Astral",
+	"Name": "Comet",
+	"Description": "The user summons a crystal of condensed energy before hurtling it after its foe.",
+	"Damage": 50,
+	"AttackType": "Special",
+	"Target": "Single",
+	"StaminaCost": 40,
+	"UserStatuses": [],
+	"TargetStatuses": []
+}

--- a/HackmonInternals/Data/Moves/Astral/FairyFire.json
+++ b/HackmonInternals/Data/Moves/Astral/FairyFire.json
@@ -1,0 +1,17 @@
+{
+	"Id": 81,
+	"MoveType": "Astral",
+	"Name": "Fae Fire",
+	"Description": "The user ignites its foe with enigmatic flames, leaving them with lingering burns.",
+	"Damage": 40,
+	"AttackType": "Physical",
+	"Target": "Special",
+	"StaminaCost": 25,
+	"UserStatuses": [],
+	"TargetStatuses": [
+		{
+			"Name": "Burn",
+			"Duration": 2
+		}
+	]
+}

--- a/HackmonInternals/Data/Moves/Astral/LuminStrike.json
+++ b/HackmonInternals/Data/Moves/Astral/LuminStrike.json
@@ -1,0 +1,12 @@
+{
+	"Id": 79,
+	"MoveType": "Astral",
+	"Name": "Luminous Strike",
+	"Description": "The user imbues a part of its body with vibrant energy before striking its foe.",
+	"Damage": 40,
+	"AttackType": "Physical",
+	"Target": "Single",
+	"StaminaCost": 25,
+	"UserStatuses": [],
+	"TargetStatuses": []
+}

--- a/HackmonInternals/Data/Moves/Astral/LunarBeam.json
+++ b/HackmonInternals/Data/Moves/Astral/LunarBeam.json
@@ -1,0 +1,12 @@
+{
+	"Id": 78,
+	"MoveType": "Astral",
+	"Name": "Lunar Beam",
+	"Description": "The user unleashes a powerful torrent of astral energy upon its foe.",
+	"Damage": 80,
+	"AttackType": "Special",
+	"Target": "Single",
+	"StaminaCost": 75,
+	"UserStatuses": [],
+	"TargetStatuses": []
+}

--- a/HackmonInternals/Data/Moves/Astral/Sparkle.json
+++ b/HackmonInternals/Data/Moves/Astral/Sparkle.json
@@ -1,0 +1,12 @@
+{
+	"Id": 23,
+	"MoveType": "Astral",
+	"Name": "Sparkle",
+	"Description": "The user showers its foe in stinging sparkling energy.",
+	"Damage": 25,
+	"AttackType": "Special",
+	"Target": "Single",
+	"StaminaCost": 15,
+	"UserStatuses": [],
+	"TargetStatuses": []
+}

--- a/HackmonInternals/Data/Moves/Astral/StarCrash.json
+++ b/HackmonInternals/Data/Moves/Astral/StarCrash.json
@@ -1,0 +1,12 @@
+{
+	"Id": 80,
+	"MoveType": "Astral",
+	"Name": "Star Crash",
+	"Description": "The user coats itself with luminous energy to resemble a star, before hurtling itself at its foe.",
+	"Damage": 65,
+	"AttackType": "Physical",
+	"Target": "Single",
+	"StaminaCost": 55,
+	"UserStatuses": [],
+	"TargetStatuses": []
+}


### PR DESCRIPTION
Closes #57

Adds a total of six new moves for the Astral type. None of them require any special handling.